### PR TITLE
auth for docker registry 

### DIFF
--- a/config/docker_auth/auth_config.yml
+++ b/config/docker_auth/auth_config.yml
@@ -1,0 +1,28 @@
+# Reference: https://github.com/cesanta/docker_auth/blob/main/examples/reference.yml
+server:
+  addr: ':5001'
+  certificate: '/etc/letsencrypt/live/docker.cdot.systems/fullchain.pem'
+  key: '/etc/letsencrypt/live/docker.cdot.systems/privkey.pem'
+
+token:
+  issuer: 'Docker auth issuer'
+  expiration: 900
+
+users:
+  # Password is specified as a BCrypt hash. Use htpasswd to generate.
+  'admin':
+    password: '' # Need generate a password
+  'telescope-ci':
+    password: '' # Need generate a password
+  '': {}
+
+acl:
+  - match: { account: 'admin' }
+    actions: ['*']
+    comment: 'Admin has full access to everything.'
+  - match: { account: 'telescope-ci' }
+    actions: ['push', 'pull']
+    comment: 'Telescope CI has push and pull access'
+  - match: { account: '' }
+    actions: ['pull']
+    comment: 'Any user has pull access'

--- a/config/etc/nginx/nginx.conf
+++ b/config/etc/nginx/nginx.conf
@@ -46,7 +46,18 @@ http {
       ## See the map directive above where this variable is defined.
       add_header 'Docker-Distribution-Api-Version' $docker_distribution_api_version always;
 
-      proxy_pass                          http://registry:5000; #${PORT};
+      proxy_pass                          http://registry:5000;
+      proxy_set_header  Host              $http_host;   # required for docker client's sake
+      proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
+      proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_read_timeout                  900;
+    }
+
+    # Ref: https://github.com/cesanta/docker_auth/issues/184
+    location /auth {
+      proxy_pass                          https://docker_auth:5001/auth;
+      proxy_ssl_trusted_certificate       /etc/letsencrypt/live/docker.cdot.systems/fullchain.pem;
       proxy_set_header  Host              $http_host;   # required for docker client's sake
       proxy_set_header  X-Real-IP         $remote_addr; # pass on real client's IP
       proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;

--- a/config/registry/config.yml
+++ b/config/registry/config.yml
@@ -1,0 +1,23 @@
+# https://docs.docker.com/registry/configuration/
+
+version: 0.1
+log:
+  level: info # info, warn, error
+  fields:
+    service: registry
+
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /mnt/docker0storage/registry
+
+http:
+  addr: ':5000'
+
+auth:
+  token:
+    issuer: 'Docker auth issuer'
+    realm: 'https://docker.cdot.systems/auth'
+    service: 'Docker registry'
+    rootcertbundle: /etc/letsencrypt/live/docker.cdot.systems/fullchain.pem

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,18 @@
 #https://docs.docker.com/registry/deploying/#deploy-your-registry-using-a-compose-file
 services:
   nginx:
-    image: "nginx:stable-alpine"
+    image: 'nginx:stable-alpine'
     ports:
       - 443:443
     restart: unless-stopped
     volumes:
       - ./config/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
       - /etc/letsencrypt:/etc/letsencrypt
-    depends_on: 
+    depends_on:
       - registry
+      - docker_auth
     command: /bin/sh -c "while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g 'daemon off;'"
-  
+
   # SSL certificate management for nginx
   certbot:
     image: certbot/certbot
@@ -21,9 +22,20 @@ services:
     restart: always
     # This will check if your certificate is up for renewal every 12 hours as recommended by Let’s Encrypt
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
- 
+
   registry:
     restart: always
     image: registry:2
     volumes:
+      - /etc/letsencrypt:/etc/letsencrypt
+      - ./config/registry/config.yml:/etc/docker/registry/config.yml
       - /mnt/docker0storage/registry:/var/lib/registry
+
+  docker_auth:
+    image: cesanta/docker_auth
+    volumes:
+      - ./config/docker_auth:/config:ro
+      - /var/log/docker_auth:/logs
+      - /etc/letsencrypt:/etc/letsencrypt
+    command: /config/auth_config.yml
+    restart: always


### PR DESCRIPTION
Fixes #3 
Basic auth setup for our docker registry.

TODO:
- We need to add registry config file, and add the code below.
  ```yml
  auth:
    token:
      issuer: 'Docker auth issuer'
      realm: "https://docker.cdot.systems/auth"
      service: "auth service"
  ```
- Generate password with htpasswd for our account.
- Figured out the certificate and key thing https://github.com/cesanta/docker_auth/blob/4d80afcb425e5df9e84b6e9c9ba51689394cc8b8/examples/simple.yml#L12-L13
- Later on `auth_config.yml` will also be mounted as volume since we don't wanna expose on git

