### PR TITLE
Move auth_config.yml to auth_config_example.yml, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,21 @@ $ docker push docker.cdot.systems/example:v1.0.5
 
 ## Administration
 
-The server is run out of `/usr/local/src/docker.cdot.systems`.
+### Setup
+
+The server is run out of `/usr/local/src/docker.cdot.systems`.  It requires you to install:
+
+- git
+- docker
+- httpd-tools
+
+The `docker_auth` configuration needs to be defined in `config/docker_auth/auth_config.yml`.  An example config file is available at [config/docker_auth/auth_config_example.yml](config/docker_auth/auth_config_example.yml).  Start by copying it to `config/docker_auth/auth_config.yml`:
+
+```sh
+$ cp config/docker_auth/auth_config_example.yml config/docker_auth/auth_config.yml
+```
+
+### Running the Server
 
 To start the server, use:
 
@@ -51,9 +65,9 @@ $ cd /usr/local/src/docker.cdot.systems
 $ docker-compose down
 ```
 
-## Accounts
+### Accounts
 
-Docker accounts are defined in [config/docker_auth/auth_config.yml](config/docker_auth/auth_config.yml) like so:
+Update the `users` and `acl` sections of `config/docker_auth/auth_config.yml` in order to create your users:
 
 ```yml
 users:
@@ -78,14 +92,14 @@ acl:
 
 ### Adding/Modifying User Accounts
 
-Generate a new hash for the user's password (e.g., `user=test-user`, `password=1234`):
+To create a new user/password pair, generate a hash for the user's password. For example:
 
 ```sh
 $ htpasswd -n -B -b -C 10 test-user 1234
 test-user:$2y$10$Sx4ERcQPJ9z8PY5MjWTus.0tdL17o/VokiM7oPe8aRshsvL1dwRJC
 ```
 
-Update [config/docker_auth/auth_config.yml](config/docker_auth/auth_config.yml) to include the user under `users`:
+Update `config/docker_auth/auth_config.yml` to include the user under `users`:
 
 ```yml
 users:

--- a/config/docker_auth/auth_config_example.yml
+++ b/config/docker_auth/auth_config_example.yml
@@ -1,4 +1,6 @@
+# NOTE: this is an example config, meant to be copied to ./auth_config.yml and updated.
 # Reference: https://github.com/cesanta/docker_auth/blob/main/examples/reference.yml
+
 server:
   addr: ':5001'
   certificate: '/etc/letsencrypt/live/docker.cdot.systems/fullchain.pem'


### PR DESCRIPTION
This makes our auth_config work as a template, so we don't overwrite it when we `pull` changes later, and lost accounts.

I've also updated the docs to reflect the change.  See if things make sense to you.