### PR TITLE
Add configs to support docker hub proxy

### DIFF
--- a/config/etc/daemon.json
+++ b/config/etc/daemon.json
@@ -1,0 +1,3 @@
+{
+    "registry-mirrors": ["https://docker.cdot.systems"]
+}

--- a/config/registry/config.yml
+++ b/config/registry/config.yml
@@ -21,3 +21,6 @@ auth:
     realm: 'https://docker.cdot.systems/auth'
     service: 'Docker registry'
     rootcertbundle: /etc/letsencrypt/live/docker.cdot.systems/fullchain.pem
+
+proxy:
+  remoteurl: https://registry-1.docker.io/


### PR DESCRIPTION
Fixes #9 

I followed this guide https://docs.docker.com/registry/recipes/mirror/#run-a-registry-as-a-pull-through-cache

- Add `etc/deamon.json` to specify what registry to mirror 
- Add `proxy.remoteurl`