### PR TITLE
Closes #9: Support pull-through proxying of Docker Hub

### DIFF
--- a/config/registry/config.yml
+++ b/config/registry/config.yml
@@ -21,3 +21,6 @@ auth:
     realm: 'https://docker.cdot.systems/auth'
     service: 'Docker registry'
     rootcertbundle: /etc/letsencrypt/live/docker.cdot.systems/fullchain.pem
+
+proxy:
+  remoteurl: https://registry-1.docker.io/

--- a/config/registry/daemon.json
+++ b/config/registry/daemon.json
@@ -1,0 +1,3 @@
+{
+  "registry-mirrors": ["https://docker.cdot.systems"]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt
       - ./config/registry/config.yml:/etc/docker/registry/config.yml
+      - ./config/registry/daemon.json:/etc/docker/daemon.json
       - /mnt/docker0storage/registry:/var/lib/registry
 
   docker_auth:


### PR DESCRIPTION
Closes #9 

This PR adds support for pull-through proxying of docker hub. This way, we can cache Redis, ES, etc from Docker hub in our registry and pull from it.

More info here:
https://docs.docker.com/registry/recipes/mirror/#run-a-registry-as-a-pull-through-cache